### PR TITLE
Remove unused aggregate-param

### DIFF
--- a/appointments.go
+++ b/appointments.go
@@ -294,7 +294,6 @@ type GetAppointmentsByZipCodeParams struct {
 	ZipCode   string    `json:"zipCode"`
 	From      time.Time `json:"from"`
 	To        time.Time `json:"to"`
-	Aggregate bool      `json:"aggregate"`
 }
 
 // GetProvidersByZipCode


### PR DESCRIPTION
Implemented in it's own endpoint now. Can be removed.